### PR TITLE
Update 11 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.WebServer.nuspec
+++ b/MakoIoT.Device.WebServer.nuspec
@@ -17,21 +17,21 @@
     <description>On-device web server base library for MAKO-IoT</description>
     <tags>nanoFramework C# csharp netmf netnf mako-iot server web api rest</tags>
     <dependencies>
-	    <dependency id="MakoIoT.Device.Services.FileStorage" version="1.1.1.4387"/>
-	    <dependency id="MakoIoT.Device.Services.Interface" version="1.0.48.22567"/>
-	    <dependency id="MakoIoT.Device.Services.Server" version="1.0.77.42584"/>
-	    <dependency id="MakoIoT.Device.Utilities.String" version="1.0.37.35071"/>
-	    <dependency id="nanoFramework.CoreLibrary" version="1.15.5"/>
-	    <dependency id="nanoFramework.DependencyInjection" version="1.1.11"/>
-	    <dependency id="nanoFramework.Runtime.Events" version="1.11.18"/>
-	    <dependency id="nanoFramework.System.Collections" version="1.5.45"/>
-	    <dependency id="nanoFramework.System.IO.FileSystem" version="1.1.66"/>
-	    <dependency id="nanoFramework.System.IO.Streams" version="1.1.75"/>
-	    <dependency id="nanoFramework.System.Net" version="1.11.1"/>
-	    <dependency id="nanoFramework.System.Net.Http" version="1.5.150"/>
-	    <dependency id="nanoFramework.System.Runtime" version="1.0.27"/>
-	    <dependency id="nanoFramework.System.Text" version="1.2.54"/>
-	    <dependency id="nanoFramework.System.Threading" version="1.1.32"/>
+      <dependency id="MakoIoT.Device.Services.FileStorage" version="1.1.1.4387" />
+      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.48.22567" />
+      <dependency id="MakoIoT.Device.Services.Server" version="1.0.77.42584" />
+      <dependency id="MakoIoT.Device.Utilities.String" version="1.0.37.35071" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.16.11" />
+      <dependency id="nanoFramework.DependencyInjection" version="1.1.25" />
+      <dependency id="nanoFramework.Runtime.Events" version="1.11.29" />
+      <dependency id="nanoFramework.System.Collections" version="1.5.59" />
+      <dependency id="nanoFramework.System.IO.FileSystem" version="1.1.78" />
+      <dependency id="nanoFramework.System.IO.Streams" version="1.1.86" />
+      <dependency id="nanoFramework.System.Net" version="1.11.27" />
+      <dependency id="nanoFramework.System.Net.Http" version="1.5.175" />
+      <dependency id="nanoFramework.System.Runtime" version="1.0.28" />
+      <dependency id="nanoFramework.System.Text" version="1.3.16" />
+      <dependency id="nanoFramework.System.Threading" version="1.1.46" />
     </dependencies>
   </metadata>
   <files>

--- a/src/MakoIoT.Device.WebServer/MakoIoT.Device.WebServer.nfproj
+++ b/src/MakoIoT.Device.WebServer/MakoIoT.Device.WebServer.nfproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <NanoFrameworkProjectSystemPath>$(MSBuildExtensionsPath)\nanoFramework\v1.0\</NanoFrameworkProjectSystemPath>
@@ -29,38 +29,38 @@
     <Reference Include="MakoIoT.Device.Utilities.String">
       <HintPath>..\..\packages\MakoIoT.Device.Utilities.String.1.0.37.35071\lib\MakoIoT.Device.Utilities.String.dll</HintPath>
     </Reference>
-    <Reference Include="mscorlib">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.16.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.16.11\lib\mscorlib.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.DependencyInjection">
-      <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.11\lib\nanoFramework.DependencyInjection.dll</HintPath>
+    <Reference Include="nanoFramework.DependencyInjection, Version=1.1.25.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.25\lib\nanoFramework.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events">
-      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.11.18\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    <Reference Include="nanoFramework.Runtime.Events, Version=1.11.29.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.11.29\lib\nanoFramework.Runtime.Events.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.System.Collections">
-      <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.45\lib\nanoFramework.System.Collections.dll</HintPath>
+    <Reference Include="nanoFramework.System.Collections, Version=1.5.59.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.59\lib\nanoFramework.System.Collections.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.System.Runtime">
-      <HintPath>..\..\packages\nanoFramework.System.Runtime.1.0.27\lib\nanoFramework.System.Runtime.dll</HintPath>
+    <Reference Include="nanoFramework.System.Runtime, Version=1.0.28.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Runtime.1.0.28\lib\nanoFramework.System.Runtime.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.System.Text">
-      <HintPath>..\..\packages\nanoFramework.System.Text.1.2.54\lib\nanoFramework.System.Text.dll</HintPath>
+    <Reference Include="nanoFramework.System.Text, Version=1.3.16.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Text.1.3.16\lib\nanoFramework.System.Text.dll</HintPath>
     </Reference>
-    <Reference Include="System.IO.FileSystem">
-      <HintPath>..\..\packages\nanoFramework.System.IO.FileSystem.1.1.66\lib\System.IO.FileSystem.dll</HintPath>
+    <Reference Include="System.IO.FileSystem, Version=1.1.78.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.IO.FileSystem.1.1.78\lib\System.IO.FileSystem.dll</HintPath>
     </Reference>
-    <Reference Include="System.IO.Streams">
-      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.75\lib\System.IO.Streams.dll</HintPath>
+    <Reference Include="System.IO.Streams, Version=1.1.86.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.86\lib\System.IO.Streams.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net">
-      <HintPath>..\..\packages\nanoFramework.System.Net.1.11.1\lib\System.Net.dll</HintPath>
+    <Reference Include="System.Net, Version=1.11.27.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.1.11.27\lib\System.Net.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http">
-      <HintPath>..\..\packages\nanoFramework.System.Net.Http.1.5.150\lib\System.Net.Http.dll</HintPath>
+    <Reference Include="System.Net.Http, Version=1.5.175.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.Http.1.5.175\lib\System.Net.Http.dll</HintPath>
     </Reference>
-    <Reference Include="System.Threading">
-      <HintPath>..\..\packages\nanoFramework.System.Threading.1.1.32\lib\System.Threading.dll</HintPath>
+    <Reference Include="System.Threading, Version=1.1.46.1709, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Threading.1.1.46\lib\System.Threading.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/MakoIoT.Device.WebServer/packages.config
+++ b/src/MakoIoT.Device.WebServer/packages.config
@@ -4,15 +4,15 @@
   <package id="MakoIoT.Device.Services.Interface" version="1.0.48.22567" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Server" version="1.0.77.42584" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.String" version="1.0.37.35071" targetFramework="netnano1.0" />
-  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
-  <package id="nanoFramework.DependencyInjection" version="1.1.11" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Runtime.Events" version="1.11.18" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Collections" version="1.5.45" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.IO.FileSystem" version="1.1.66" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.IO.Streams" version="1.1.75" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net" version="1.11.1" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net.Http" version="1.5.150" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Runtime" version="1.0.27" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Text" version="1.2.54" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Threading" version="1.1.32" targetFramework="netnano1.0" />
+  <package id="nanoFramework.CoreLibrary" version="1.16.11" targetFramework="netnano1.0" />
+  <package id="nanoFramework.DependencyInjection" version="1.1.25" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Runtime.Events" version="1.11.29" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Collections" version="1.5.59" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.FileSystem" version="1.1.78" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.Streams" version="1.1.86" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net" version="1.11.27" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net.Http" version="1.5.175" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Runtime" version="1.0.28" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Text" version="1.3.16" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Threading" version="1.1.46" targetFramework="netnano1.0" />
 </packages>


### PR DESCRIPTION
Bumps nanoFramework.CoreLibrary from 1.15.5 to 1.16.11</br>Bumps nanoFramework.DependencyInjection from 1.1.11 to 1.1.25</br>Bumps nanoFramework.Runtime.Events from 1.11.18 to 1.11.29</br>Bumps nanoFramework.System.Collections from 1.5.45 to 1.5.59</br>Bumps nanoFramework.System.IO.FileSystem from 1.1.66 to 1.1.78</br>Bumps nanoFramework.System.IO.Streams from 1.1.75 to 1.1.86</br>Bumps nanoFramework.System.Net from 1.11.1 to 1.11.27</br>Bumps nanoFramework.System.Net.Http from 1.5.150 to 1.5.175</br>Bumps nanoFramework.System.Runtime from 1.0.27 to 1.0.28</br>Bumps nanoFramework.System.Text from 1.2.54 to 1.3.16</br>Bumps nanoFramework.System.Threading from 1.1.32 to 1.1.46</br>
[version update]

### :warning: This is an automated update. :warning:
