### PR TITLE
Update 12 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.WebServer.nuspec
+++ b/MakoIoT.Device.WebServer.nuspec
@@ -18,20 +18,20 @@
     <tags>nanoFramework C# csharp netmf netnf mako-iot server web api rest</tags>
     <dependencies>
       <dependency id="MakoIoT.Device.Services.FileStorage" version="1.1.11.41578" />
-      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.54.39044" />
+      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.55.11594" />
       <dependency id="MakoIoT.Device.Services.Server" version="1.0.88.27496" />
-      <dependency id="MakoIoT.Device.Utilities.String" version="1.0.42.9118" />
-      <dependency id="nanoFramework.CoreLibrary" version="1.17.7" />
-      <dependency id="nanoFramework.DependencyInjection" version="1.1.30" />
-      <dependency id="nanoFramework.Runtime.Events" version="1.11.31" />
-      <dependency id="nanoFramework.System.Collections" version="1.5.63" />
-      <dependency id="nanoFramework.System.IO.FileSystem" version="1.1.83" />
-      <dependency id="nanoFramework.System.IO.Streams" version="1.1.91" />
-      <dependency id="nanoFramework.System.Net" version="1.11.37" />
-      <dependency id="nanoFramework.System.Net.Http" version="1.5.192" />
+      <dependency id="MakoIoT.Device.Utilities.String" version="1.0.43.34490" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
+      <dependency id="nanoFramework.DependencyInjection" version="1.1.32" />
+      <dependency id="nanoFramework.Runtime.Events" version="1.11.32" />
+      <dependency id="nanoFramework.System.Collections" version="1.5.67" />
+      <dependency id="nanoFramework.System.IO.FileSystem" version="1.1.85" />
+      <dependency id="nanoFramework.System.IO.Streams" version="1.1.94" />
+      <dependency id="nanoFramework.System.Net" version="1.11.42" />
+      <dependency id="nanoFramework.System.Net.Http" version="1.5.193" />
       <dependency id="nanoFramework.System.Runtime" version="1.0.28" />
-      <dependency id="nanoFramework.System.Text" version="1.3.36" />
-      <dependency id="nanoFramework.System.Threading" version="1.1.50" />
+      <dependency id="nanoFramework.System.Text" version="1.3.42" />
+      <dependency id="nanoFramework.System.Threading" version="1.1.52" />
     </dependencies>
   </metadata>
   <files>

--- a/src/MakoIoT.Device.WebServer/MakoIoT.Device.WebServer.nfproj
+++ b/src/MakoIoT.Device.WebServer/MakoIoT.Device.WebServer.nfproj
@@ -21,46 +21,46 @@
       <HintPath>..\..\packages\MakoIoT.Device.Services.FileStorage.1.1.11.41578\lib\MakoIoT.Device.Services.FileStorage.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.54.39044\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.55.11594\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Server, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.88.27496\lib\MakoIoT.Device.Services.Server.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Utilities.String, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Utilities.String.1.0.42.9118\lib\MakoIoT.Device.Utilities.String.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Utilities.String.1.0.43.34490\lib\MakoIoT.Device.Utilities.String.dll</HintPath>
     </Reference>
-    <Reference Include="mscorlib, Version=1.17.7.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.17.7\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.17.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.17.11\lib\mscorlib.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.DependencyInjection, Version=1.1.30.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.30\lib\nanoFramework.DependencyInjection.dll</HintPath>
+    <Reference Include="nanoFramework.DependencyInjection, Version=1.1.32.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.32\lib\nanoFramework.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events, Version=1.11.31.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.11.31\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    <Reference Include="nanoFramework.Runtime.Events, Version=1.11.32.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.11.32\lib\nanoFramework.Runtime.Events.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.System.Collections, Version=1.5.63.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.63\lib\nanoFramework.System.Collections.dll</HintPath>
+    <Reference Include="nanoFramework.System.Collections, Version=1.5.67.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.67\lib\nanoFramework.System.Collections.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.System.Runtime, Version=1.0.28.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.Runtime.1.0.28\lib\nanoFramework.System.Runtime.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.System.Text, Version=1.3.36.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Text.1.3.36\lib\nanoFramework.System.Text.dll</HintPath>
+    <Reference Include="nanoFramework.System.Text, Version=1.3.42.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Text.1.3.42\lib\nanoFramework.System.Text.dll</HintPath>
     </Reference>
-    <Reference Include="System.IO.FileSystem, Version=1.1.83.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.IO.FileSystem.1.1.83\lib\System.IO.FileSystem.dll</HintPath>
+    <Reference Include="System.IO.FileSystem, Version=1.1.85.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.IO.FileSystem.1.1.85\lib\System.IO.FileSystem.dll</HintPath>
     </Reference>
-    <Reference Include="System.IO.Streams, Version=1.1.91.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.91\lib\System.IO.Streams.dll</HintPath>
+    <Reference Include="System.IO.Streams, Version=1.1.94.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.94\lib\System.IO.Streams.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net, Version=1.11.37.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Net.1.11.37\lib\System.Net.dll</HintPath>
+    <Reference Include="System.Net, Version=1.11.42.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.1.11.42\lib\System.Net.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http, Version=1.5.192.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Net.Http.1.5.192\lib\System.Net.Http.dll</HintPath>
+    <Reference Include="System.Net.Http, Version=1.5.193.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.Http.1.5.193\lib\System.Net.Http.dll</HintPath>
     </Reference>
-    <Reference Include="System.Threading, Version=1.1.50.48563, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Threading.1.1.50\lib\System.Threading.dll</HintPath>
+    <Reference Include="System.Threading, Version=1.1.52.34401, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Threading.1.1.52\lib\System.Threading.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/MakoIoT.Device.WebServer/packages.config
+++ b/src/MakoIoT.Device.WebServer/packages.config
@@ -1,18 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MakoIoT.Device.Services.FileStorage" version="1.1.11.41578" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.54.39044" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.55.11594" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Server" version="1.0.88.27496" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Utilities.String" version="1.0.42.9118" targetFramework="netnano1.0" />
-  <package id="nanoFramework.CoreLibrary" version="1.17.7" targetFramework="netnano1.0" />
-  <package id="nanoFramework.DependencyInjection" version="1.1.30" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Runtime.Events" version="1.11.31" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Collections" version="1.5.63" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.IO.FileSystem" version="1.1.83" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.IO.Streams" version="1.1.91" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net" version="1.11.37" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net.Http" version="1.5.192" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Utilities.String" version="1.0.43.34490" targetFramework="netnano1.0" />
+  <package id="nanoFramework.CoreLibrary" version="1.17.11" targetFramework="netnano1.0" />
+  <package id="nanoFramework.DependencyInjection" version="1.1.32" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Runtime.Events" version="1.11.32" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Collections" version="1.5.67" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.FileSystem" version="1.1.85" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.Streams" version="1.1.94" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net" version="1.11.42" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net.Http" version="1.5.193" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Runtime" version="1.0.28" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Text" version="1.3.36" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Threading" version="1.1.50" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Text" version="1.3.42" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Threading" version="1.1.52" targetFramework="netnano1.0" />
 </packages>


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.Interface from 1.0.54.39044 to 1.0.55.11594</br>Bumps MakoIoT.Device.Utilities.String from 1.0.42.9118 to 1.0.43.34490</br>Bumps nanoFramework.CoreLibrary from 1.17.7 to 1.17.11</br>Bumps nanoFramework.DependencyInjection from 1.1.30 to 1.1.32</br>Bumps nanoFramework.Runtime.Events from 1.11.31 to 1.11.32</br>Bumps nanoFramework.System.Collections from 1.5.63 to 1.5.67</br>Bumps nanoFramework.System.IO.FileSystem from 1.1.83 to 1.1.85</br>Bumps nanoFramework.System.IO.Streams from 1.1.91 to 1.1.94</br>Bumps nanoFramework.System.Net from 1.11.37 to 1.11.42</br>Bumps nanoFramework.System.Net.Http from 1.5.192 to 1.5.193</br>Bumps nanoFramework.System.Text from 1.3.36 to 1.3.42</br>Bumps nanoFramework.System.Threading from 1.1.50 to 1.1.52</br>
[version update]

### :warning: This is an automated update. :warning:
