### PR TITLE
Update 2 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.WebServer.nuspec
+++ b/MakoIoT.Device.WebServer.nuspec
@@ -17,9 +17,9 @@
     <description>On-device web server base library for MAKO-IoT</description>
     <tags>nanoFramework C# csharp netmf netnf mako-iot server web api rest</tags>
     <dependencies>
-      <dependency id="MakoIoT.Device.Services.FileStorage" version="1.1.11.41578" />
+      <dependency id="MakoIoT.Device.Services.FileStorage" version="1.1.13.47059" />
       <dependency id="MakoIoT.Device.Services.Interface" version="1.0.55.11594" />
-      <dependency id="MakoIoT.Device.Services.Server" version="1.0.88.27496" />
+      <dependency id="MakoIoT.Device.Services.Server" version="1.0.89.37901" />
       <dependency id="MakoIoT.Device.Utilities.String" version="1.0.43.34490" />
       <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
       <dependency id="nanoFramework.DependencyInjection" version="1.1.32" />

--- a/src/MakoIoT.Device.WebServer/MakoIoT.Device.WebServer.nfproj
+++ b/src/MakoIoT.Device.WebServer/MakoIoT.Device.WebServer.nfproj
@@ -18,13 +18,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="MakoIoT.Device.Services.FileStorage, Version=1.1.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.FileStorage.1.1.11.41578\lib\MakoIoT.Device.Services.FileStorage.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.FileStorage.1.1.13.47059\lib\MakoIoT.Device.Services.FileStorage.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.55.11594\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Server, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.88.27496\lib\MakoIoT.Device.Services.Server.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.89.37901\lib\MakoIoT.Device.Services.Server.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Utilities.String, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\packages\MakoIoT.Device.Utilities.String.1.0.43.34490\lib\MakoIoT.Device.Utilities.String.dll</HintPath>

--- a/src/MakoIoT.Device.WebServer/packages.config
+++ b/src/MakoIoT.Device.WebServer/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.FileStorage" version="1.1.11.41578" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.FileStorage" version="1.1.13.47059" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Interface" version="1.0.55.11594" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Server" version="1.0.88.27496" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Server" version="1.0.89.37901" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.String" version="1.0.43.34490" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.17.11" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.32" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.FileStorage from 1.1.11.41578 to 1.1.13.47059</br>Bumps MakoIoT.Device.Services.Server from 1.0.88.27496 to 1.0.89.37901</br>
[version update]

### :warning: This is an automated update. :warning:
